### PR TITLE
Fix example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Built on the [Eventually](https://github.com/matthewturner/Eventually) library, 
 
 ```
 EvtManager mgr;
-StateMachineListener stateMachine;
+EvtStateMachineListener stateMachine;
 
 void setup()
 {


### PR DESCRIPTION
Use correct prefix, just like in examples/StateMachine/StateMachine.ino